### PR TITLE
Format README tree diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,51 @@
 
 ## Tree Diagram
 
-Homebrew<br>
- ┣━ (formula) git<br>
- ┣━ (formula) ffmpeg<br>
- ┣━ (formula) yt-dlp<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┗━ (setting) yt-dlp.conf<br>
- ┣━ (formula) neofetch<br>
- ┣━ (formula) wget<br>
- ┣━ (formula) python<br>
- ┣━ (formula) pyenv<br>
- ┣━ (formula) openjdk<br>
- ┣━ (formula) gh<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┣━ (extension) gh-copilot<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┣━ (extension) gh-graph<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┗━ (extension) gh-info<br>
- ┣━ (formula) prettier<br>
- ┣━ (formula) vim<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┗━ (setting) .vimrc<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┗━ (extension) vim-plug<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┣━ (extension) copilot.vim<br>
- ┃&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;┗━ (extension) vim-prettier<br>
- ┣━ (formula) zsh-autocomplete<br>
- ┣━ (formula) zsh-syntax-highlighting<br>
- ┃<br>
- ┣━ (cask)(font) monaspace<br>
- ┣━ (cask)(font) sf-pro<br>
- ┣━ (cask)(font) sf-compact<br>
- ┣━ (cask)(font) sf-mono<br>
- ┣━ (cask)(font) new-york<br>
- ┣━ (cask)(font) noto-sans-jp<br>
- ┣━ (cask)(font) noto-serif-jp<br>
- ┃<br>
- ┣━ (cask) sf-symbols<br>
- ┣━ (cask) chatgpt<br>
- ┣━ (cask) github-copilot-for-xcode<br>
- ┣━ (cask) docker<br>
- ┣━ (cask) parallels<br>
- ┣━ (cask) parallels-toolbox<br>
- ┣━ (cask) hhkb<br>
- ┣━ (cask) deepl<br>
- ┣━ (cask) microsoft-edge<br>
- ┣━ (cask) visual-studio-code<br>
- ┣━ (cask) notion<br>
- ┣━ (cask) steam<br>
- ┣━ (cask) minecraft<br>
- ┣━ (cask) nvidia-geforce-now<br>
- ┗━ (cask) discord<br>
+```
+Homebrew
+├─ (formula) git
+├─ (formula) ffmpeg
+├─ (formula) yt-dlp
+│  └─ (setting) yt-dlp.conf
+├─ (formula) neofetch
+├─ (formula) wget
+├─ (formula) python
+├─ (formula) pyenv
+├─ (formula) openjdk
+├─ (formula) gh
+│  ├─ (extension) gh-copilot
+│  ├─ (extension) gh-graph
+│  └─ (extension) gh-info
+├─ (formula) prettier
+├─ (formula) vim
+│  └─ (setting) .vimrc
+│     └─ (extension) vim-plug
+│        ├─ (extension) copilot.vim
+│        └─ (extension) vim-prettier
+├─ (formula) zsh-autocomplete
+├─ (formula) zsh-syntax-highlighting
+│
+├─ (cask)(font) monaspace
+├─ (cask)(font) sf-pro
+├─ (cask)(font) sf-compact
+├─ (cask)(font) sf-mono
+├─ (cask)(font) new-york
+├─ (cask)(font) noto-sans-jp
+├─ (cask)(font) noto-serif-jp
+│
+├─ (cask) sf-symbols
+├─ (cask) chatgpt
+├─ (cask) github-copilot-for-xcode
+├─ (cask) docker
+├─ (cask) parallels
+├─ (cask) parallels-toolbox
+├─ (cask) hhkb
+├─ (cask) deepl
+├─ (cask) microsoft-edge
+├─ (cask) visual-studio-code
+├─ (cask) notion
+├─ (cask) steam
+├─ (cask) minecraft
+├─ (cask) nvidia-geforce-now
+└─ (cask) discord
+```


### PR DESCRIPTION
## Summary
- reformat README to display the Homebrew tree as a fenced ASCII diagram

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fbf8666988331a6b49c1336329bcc